### PR TITLE
This PR fixes the issue #10

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -108,7 +108,7 @@ class LLMRayActor:
 
             if len(requests) > 0:
                 # For now we assume that all requests have the same sampling params
-                responses = self.llm.generate(vllm_vision_input, sampling_params=sampling_params)
+                responses = self.llm.generate(requests, sampling_params=sampling_params)
             else:
                 responses = []
 


### PR DESCRIPTION
The add_requests_vlm function contains an incorrect variable reference, which results in some requests being dropped when the number of vLLM engines is less than the world size.